### PR TITLE
Update viewer ui for line thickness and selection

### DIFF
--- a/static/scripts/render_goban_canvas.js
+++ b/static/scripts/render_goban_canvas.js
@@ -26,6 +26,8 @@ var cursor_x_initial = null;
 var cursor_y_initial = null;
 
 var panning = false;
+// Flag to suppress click selection immediately after a drag-based pan
+window.suppressNextClickSelection = false;
 
 // Tooltip and hover state
 var tooltipEl = document.getElementById("stone-tooltip");
@@ -80,6 +82,14 @@ canvas.addEventListener("mousemove", (e) => {
 
 ["mouseup", "mouseleave"].forEach((event_name) => {
     canvas.addEventListener(event_name, () => {
+        // If releasing after a drag, mark to suppress the following click selection
+        if (event_name === "mouseup") {
+            const dragDistance = Math.hypot(_x_offset, _y_offset);
+            // Use a small threshold to avoid accidental suppression on micro-movements
+            if (dragDistance > 3) {
+                window.suppressNextClickSelection = true;
+            }
+        }
         _x += _x_offset / rulingSpacing;
         _y += _y_offset / rulingSpacing;
         _x_offset = 0;
@@ -320,7 +330,7 @@ function drawActiveAreaBoundary() {
 
     ctx.save();
     ctx.strokeStyle = "red";
-    ctx.lineWidth = rulingWidth * rulingSpacing; // match grid line thickness
+    ctx.lineWidth = 2 * rulingWidth * rulingSpacing; // doubled thickness for active area boundary
     ctx.setLineDash([]);
     ctx.strokeRect(topLeft[0], topLeft[1], widthPx, heightPx);
     ctx.restore();

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -261,6 +261,11 @@
                  (function() {
                      const canvasEl = document.getElementById('goban');
                      canvasEl.addEventListener('click', function(e) {
+                         // Ignore click if it immediately follows a drag/pan
+                         if (window.suppressNextClickSelection) {
+                             window.suppressNextClickSelection = false;
+                             return;
+                         }
                          const world = canvas2World(mouseX(e), mouseY(e));
                          const selX = Math.round(world[0]);
                          const selY = Math.round(world[1]);


### PR DESCRIPTION
Increase active area red line thickness and prevent position selection on mouse release after panning.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba82e464-bb7f-4a1b-859c-b8627d1b0a07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba82e464-bb7f-4a1b-859c-b8627d1b0a07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

