### PR TITLE
Thicken active area border in viewer

### DIFF
--- a/static/scripts/render_goban_canvas.js
+++ b/static/scripts/render_goban_canvas.js
@@ -330,7 +330,7 @@ function drawActiveAreaBoundary() {
 
     ctx.save();
     ctx.strokeStyle = "red";
-    ctx.lineWidth = 2 * rulingWidth * rulingSpacing; // doubled thickness for active area boundary
+    ctx.lineWidth = 6 * rulingWidth * rulingSpacing; // 3x current thickness for active area boundary
     ctx.setLineDash([]);
     ctx.strokeRect(topLeft[0], topLeft[1], widthPx, heightPx);
     ctx.restore();


### PR DESCRIPTION
Increase the thickness of the red lines around the active area in `viewer.html` by 3x.

---
<a href="https://cursor.com/background-agent?bcId=bc-7af5ede1-3472-4bf4-bcad-a0d4737ace39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7af5ede1-3472-4bf4-bcad-a0d4737ace39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

