### PR TITLE
Sync leaderboard stone colors to board

### DIFF
--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -282,6 +282,25 @@
                     updatePlayerScore(currentPlayer, delta);
                     updateHeaderUserScoreTo(cur + delta);
                 }
+ 
+                // Resolve the display color for a given player using the same mapping as the board
+                function getColorForPlayer(playerName) {
+                    try {
+                        if (typeof playerColorMap !== 'object' || playerColorMap === null) {
+                            if (typeof buildPlayerColorMap === 'function') {
+                                // Build the global mapping once from all stones
+                                playerColorMap = buildPlayerColorMap(stonesData, currentPlayer);
+                            } else {
+                                playerColorMap = {};
+                            }
+                        }
+                    } catch (e) {
+                        playerColorMap = playerColorMap || {};
+                    }
+                    if (currentPlayer && playerName === currentPlayer) return '#000000';
+                    // Fallback to white if player not present in mapping
+                    return (playerColorMap && playerColorMap[playerName]) ? playerColorMap[playerName] : '#FFFFFF';
+                }
 
                 function rebuildLeaderboard(x, y) {
                     const container = document.getElementById('color-legend');
@@ -308,7 +327,8 @@
                         entry.setAttribute('class', 'legend-entry');
                         const colorIcon = document.createElement('div');
                         colorIcon.setAttribute('class', 'color-icon');
-                        colorIcon.setAttribute('style', `background-color: ${color_code[i % color_code.length]};`);
+                        const colorHex = getColorForPlayer(sortedNames[i]);
+                        colorIcon.setAttribute('style', `background-color: ${colorHex};`);
                         entry.appendChild(colorIcon);
                         const scoreVal = Number(sortedScores[i]).toLocaleString();
                         entry.append(` ${sortedNames[i]} (${scoreVal})`);


### PR DESCRIPTION
Aligns leaderboard player colors with board stone colors by using the same global player-to-color mapping, resolving previous mismatches.

---
<a href="https://cursor.com/background-agent?bcId=bc-a98b8f47-afad-41e5-a05f-4c2674cfb639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a98b8f47-afad-41e5-a05f-4c2674cfb639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

