### PR TITLE
Pan and zoom board to selected position

### DIFF
--- a/static/scripts/render_goban_canvas.js
+++ b/static/scripts/render_goban_canvas.js
@@ -8,6 +8,7 @@ var stoneStatusRadius = 0.125; // World units.
 var stoneStatusOutlineWidth = 0.05; // World units.
 var drawRate = 60; // Hz.
 var zoomSpeed = 3; // Pixels per scroll unit.
+var initialRulingSpacing = rulingSpacing; // Remember the initial zoom level for forced pans
 
 const canvas = document.getElementById("goban");
 const ctx = canvas.getContext("2d");
@@ -51,6 +52,12 @@ window.centerOnWorldCoord = function(x, y) {
     const halfCellsY = canvas.height / (2 * rulingSpacing);
     _x = Number(x) - halfCellsX;
     _y = Number(y) - halfCellsY;
+};
+
+// Center viewport and reset zoom to the initial level
+window.centerAndResetZoom = function(x, y) {
+    rulingSpacing = initialRulingSpacing;
+    window.centerOnWorldCoord(x, y);
 };
 
 canvas.addEventListener("mousedown", (e) => {

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -53,10 +53,28 @@
                 let selectedY = Number({{ cursor[1] }});
                 
                 // Initialize canvas draw loop and selected cell highlight
-                drawLoop(stonesData, currentPlayer);
-                if (typeof setSelectedCell === 'function') {
-                    setSelectedCell(selectedX, selectedY);
-                }
+drawLoop(stonesData, currentPlayer);
+if (typeof setSelectedCell === 'function') {
+    setSelectedCell(selectedX, selectedY);
+}
+
+// On first load, if a selection is present in URL/server, pan to it and reset zoom to initial level
+(function() {
+    const params = new URLSearchParams(location.search);
+    const hasX = params.has('x');
+    const hasY = params.has('y');
+    if (hasX && hasY) {
+        const ux = Number(params.get('x'));
+        const uy = Number(params.get('y'));
+        if (Number.isFinite(ux) && Number.isFinite(uy)) {
+            if (typeof centerAndResetZoom === 'function') {
+                centerAndResetZoom(ux, uy);
+            } else if (typeof centerOnWorldCoord === 'function') {
+                centerOnWorldCoord(ux, uy);
+            }
+        }
+    }
+})();
  
                  function updateUrl(x, y) {
                      const newUrl = `${location.pathname}?x=${x}&y=${y}`;
@@ -461,11 +479,17 @@
                                  // Oldest overall
                                  next = pending.sort((a,b)=>a.since-b.since)[0];
                              }
-                             applySelection(next.x, next.y);
-                             if (typeof centerOnWorldCoord === 'function') {
-                                 centerOnWorldCoord(next.x, next.y);
-                             }
-                         });
+                             // Only pan if the selected position actually changes
+const prevX = selectedX; const prevY = selectedY;
+applySelection(next.x, next.y);
+if ((prevX !== next.x || prevY !== next.y)) {
+    if (typeof centerAndResetZoom === 'function') {
+        centerAndResetZoom(next.x, next.y);
+    } else if (typeof centerOnWorldCoord === 'function') {
+        centerOnWorldCoord(next.x, next.y);
+    }
+}
+});
                      }
                  })();
              </script>


### PR DESCRIPTION
Add auto-pan and zoom reset to the viewer on initial load and when cycling pending stones to improve viewport focus.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab7815e7-7c57-405f-b5ab-893cc354e5a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab7815e7-7c57-405f-b5ab-893cc354e5a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

