### PR TITLE
Format viewer tooltip with player and timestamp

### DIFF
--- a/static/scripts/render_goban_canvas.js
+++ b/static/scripts/render_goban_canvas.js
@@ -81,7 +81,9 @@ canvas.addEventListener("mousemove", (e) => {
     const hovered = findHoveredStone(mx, my);
     if (hovered) {
         // Use viewport coordinates for the fixed-position tooltip
-        showTooltip(`${hovered.player_name} — ${Number(hovered.player_score).toLocaleString()} stones — ${formatTimestamp(hovered.placement_time)}`, e.clientX + 12, e.clientY + 12);
+        const scoreStr = Number(hovered.player_score).toLocaleString();
+        const tooltipText = `${hovered.player_name} (${scoreStr})\n${formatTimestamp(hovered.placement_time)}`;
+        showTooltip(tooltipText, e.clientX + 12, e.clientY + 12);
     } else {
         hideTooltip();
     }

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -121,5 +121,6 @@ div#color-legend div.color-icon {
     padding: 4px 8px;
     border-radius: 4px;
     font-size: 12px;
+    white-space: pre-line;
     box-shadow: 0 2px 6px rgba(0,0,0,0.2);
 }


### PR DESCRIPTION
Format the viewer.html tooltip to display player (stone count) and timestamp on two separate lines.

---
<a href="https://cursor.com/background-agent?bcId=bc-8aefbcb6-d635-42cd-a6ca-91bfff02cd2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8aefbcb6-d635-42cd-a6ca-91bfff02cd2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

