### PR TITLE
Fix mobile pan and zoom in viewer

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -19,6 +19,9 @@ div#goban-container {
     flex-wrap: wrap;
     outline: solid 1px black;
     background-color: #cfa570;
+    /* Ensure touch interactions are handled by canvas, not the browser */
+    touch-action: none;
+    -ms-touch-action: none;
 }
 
 div#goban:hover {

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
         <title>Infinite Go</title>
         <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles/main.css') }}">
         <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/favicon.png') }}">


### PR DESCRIPTION
Fix mobile pan and zoom for the Go board viewer.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4c00af9-f94c-485b-9291-9667934aeec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b4c00af9-f94c-485b-9291-9667934aeec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

