### PR TITLE
Adjust viewport resolution and scale elements

### DIFF
--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -43,6 +43,7 @@
             </h4>
 
             <script src="{{ url_for('static', filename='scripts/color_code.js') }}"></script>
+            <script>window.VIEWPORT_RESOLUTION_SCALE = 2;</script>
             <script src="{{ url_for('static', filename='scripts/render_goban_canvas.js') }}"></script>
             <script>
                 // Make stones data reusable across features


### PR DESCRIPTION
Add a configurable viewport resolution scale to render the Goban at 2x pixel density while preserving all on-screen visual sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c95567c-5c2e-4351-93ac-0b5a873a1df3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c95567c-5c2e-4351-93ac-0b5a873a1df3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

