### PR TITLE
Fix unnecessary page reload on stone placement

### DIFF
--- a/move_validation.py
+++ b/move_validation.py
@@ -27,6 +27,7 @@ def check_valid_move(player: int, cursor: Tuple[int, int]) -> bool:
 
     return True
 
+
 def evolve_status(stone_pos):
     """
     Performs any necessary updates on the status of a stone
@@ -39,8 +40,16 @@ def evolve_status(stone_pos):
     it is considered to be related to move validation.
     """
     stone = stone_db.get_stone(*stone_pos)
-    stone_db.update_status(stone["id"], {
+    if stone is None:
+        return
+
+    current_status = stone["status"]
+    next_status = {
         "Locked": "Pending",
         "Pending": "Unlocked",
         "Unlocked": "Unlocked",
-    }[stone["status"]])
+    }[current_status]
+
+    # Only write and log an event if the status actually changes
+    if next_status != current_status:
+        stone_db.update_status(stone["id"], next_status)


### PR DESCRIPTION
Prevent unnecessary page reloads in viewer.html by logging status changes only when the status actually evolves.

Redundant status events were being logged when a stone remained Unlocked, causing `/board-changes` to return unexpected events that triggered a full client-side reload after each move.

---
<a href="https://cursor.com/background-agent?bcId=bc-310688cd-c382-45a1-b0e5-8b1a61053e6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-310688cd-c382-45a1-b0e5-8b1a61053e6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

