### PR TITLE
Fix trackpad zoom NaN error on board view

### DIFF
--- a/static/scripts/render_goban_canvas.js
+++ b/static/scripts/render_goban_canvas.js
@@ -164,11 +164,18 @@ canvas.addEventListener("wheel", (e) => {
     // Prevent page scrolling while zooming inside the board view
     e.preventDefault();
 
+    // Normalize wheel delta and ignore zero/non-finite values to avoid NaN
+    const dy = Number(e.deltaY);
+    if (!Number.isFinite(dy) || dy === 0) {
+        return;
+    }
+    const direction = dy > 0 ? 1 : -1;
+
     // Zoom around the cursor.
     // Store the current cursor position in world coordinates.
     var cursor_world_coords = canvas2World(mouseX(e), mouseY(e));
     const limits = getDynamicZoomLimits();
-    rulingSpacing = clamp(rulingSpacing - (e.deltaY / Math.abs(e.deltaY)) * zoomSpeed, limits[0], limits[1]);
+    rulingSpacing = clamp(rulingSpacing - direction * zoomSpeed, limits[0], limits[1]);
     // Move the viewport to restore the cursor position.
     var new_cursor_world_coords = canvas2World(mouseX(e), mouseY(e));
     _x += cursor_world_coords[0] - new_cursor_world_coords[0];


### PR DESCRIPTION
Fixes NaN error during trackpad zoom by guarding against zero/non-finite deltaY values.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc32f7b1-8975-4732-9460-b47947852554">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc32f7b1-8975-4732-9460-b47947852554">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

